### PR TITLE
fix：“去除 hashHistory 下的 _k 查询参数”示例错误问题修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,8 +859,8 @@ const app = dva({
 #### 去除 hashHistory 下的 _k 查询参数
 
 ```javascript
-import { useRouterHistory } from 'dva/router';
-import { createHashHistory } from 'history';
+import { useRouterHistory, createHashHistory } from 'dva/router';
+
 const app = dva({
   history: useRouterHistory(createHashHistory)({ queryKey: false }),
 });


### PR DESCRIPTION
`createHashHistory` 应该从 `dva/router` 中 import，示例中从 `history` 中引入，使用 yarn add history 提示 npm 没有这个库